### PR TITLE
activated shift in confint.gam

### DIFF
--- a/R/confint-methods.R
+++ b/R/confint-methods.R
@@ -302,10 +302,14 @@
         }
     }
 
-    const <- coef(object)
-    nms <- names(const)
-    test <- grep("Intercept", nms)
-    const <- ifelse(length(test) == 0L, 0, const[test])
+    if (shift) {
+        const <- coef(object)
+        nms <- names(const)
+        test <- grep("Intercept", nms)
+        const <- ifelse(length(test) == 0L, 0, const[test])
+    } else {
+        const <- 0
+    }
 
     ## simplify to a data frame for return
     out <- do.call("bind_rows", out)


### PR DESCRIPTION
`shift` argument in `confint.gam` does not actually have any effect. In the current code, the intercept is always added, even though the default is `shift = FALSE`. The following code from the example shows it:

```
suppressPackageStartupMessages(library("mgcv"))
set.seed(2)
dat <- gamSim(1, n = 400, dist = "normal", scale = 2)
mod <- gam(y ~ s(x0) + s(x1) + s(x2) + s(x3), data = dat, method = "REML")
##'
## point-wise interval
ci <- confint(mod, parm = "x1", type = "confidence")
head(ci)
# # A tibble: 6 x 8
#   smooth by_variable       x1   est    se  crit lower upper
#   <chr>  <fct>          <dbl> <dbl> <dbl> <dbl> <dbl> <dbl>
# 1 s(x1)  NA          0.000663  5.89 0.329  1.96  5.24  6.53
# 2 s(x1)  NA          0.00568   5.90 0.320  1.96  5.27  6.52
# 3 s(x1)  NA          0.0107    5.90 0.312  1.96  5.29  6.51
# 4 s(x1)  NA          0.0157    5.91 0.304  1.96  5.31  6.51
# 5 s(x1)  NA          0.0207    5.92 0.296  1.96  5.34  6.50
# 6 s(x1)  NA          0.0258    5.92 0.288  1.96  5.36  6.49

ci <- confint(mod, parm = "x1", type = "confidence", shift = TRUE)
head(ci)
# # A tibble: 6 x 8
#   smooth by_variable       x1   est    se  crit lower upper
#   <chr>  <fct>          <dbl> <dbl> <dbl> <dbl> <dbl> <dbl>
# 1 s(x1)  NA          0.000663  5.89 0.329  1.96  5.24  6.53
# 2 s(x1)  NA          0.00568   5.90 0.320  1.96  5.27  6.52
# 3 s(x1)  NA          0.0107    5.90 0.312  1.96  5.29  6.51
# 4 s(x1)  NA          0.0157    5.91 0.304  1.96  5.31  6.51
# 5 s(x1)  NA          0.0207    5.92 0.296  1.96  5.34  6.50
# 6 s(x1)  NA          0.0258    5.92 0.288  1.96  5.36  6.49
```

After the patch, `shift = FALSE` works as expected:

```
## point-wise interval
ci <- confint(mod, parm = "x1", type = "confidence")
head(ci)
# # A tibble: 6 x 8
#   smooth by_variable       x1   est    se  crit lower upper
#   <chr>  <fct>          <dbl> <dbl> <dbl> <dbl> <dbl> <dbl>
# 1 s(x1)  NA          0.000663 -1.94 0.329  1.96 -2.59 -1.30
# 2 s(x1)  NA          0.00568  -1.94 0.320  1.96 -2.57 -1.31
# 3 s(x1)  NA          0.0107   -1.93 0.312  1.96 -2.54 -1.32
# 4 s(x1)  NA          0.0157   -1.92 0.304  1.96 -2.52 -1.33
# 5 s(x1)  NA          0.0207   -1.92 0.296  1.96 -2.50 -1.34
# 6 s(x1)  NA          0.0258   -1.91 0.288  1.96 -2.47 -1.34
```
