### PR TITLE
fix bug in `link()` and `link_inv()` with scaled t family

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -118,6 +118,9 @@ can handle more types of models and smooths, especially so in the case of
 * `smooth_samples()` would fail if the model contained random effect "smooths".
   These are now ignored with a message when running `smooth_samples()`.
   Reported by @isabellaghement in #121
+  
+* `inv_link()` would return NULL for GAMs with scaled t family. #130 reported by
+  @Aariq
 
 # gratia 0.6.0
 

--- a/R/family-utils.R
+++ b/R/family-utils.R
@@ -291,6 +291,9 @@
     if (identical(distr, "scaled t")) {
         distr <- "scaled_t"
     }
+    if (grepl("^Scaled t", distr)) {
+      distr <- "scaled_t"
+    }
     if (identical(distr, "Ordered Categorical")) {
         distr <- "ocat"
     }
@@ -602,11 +605,15 @@
             if (!grepl(type, fam, ignore.case = TRUE)) {
                 stop("'family' is not of type '\"", type, "\"'", call. = FALSE)
             }
+        } else if (identical(type, "scaled t")) {
+          if (!grepl(type, fam, ignore.case = TRUE)) {
+            stop("'family' is not of type '\"", type, "\"'", call. = FALSE)
+          }
         } else {
             if (!identical(fam, type)) {
                 stop("'family' is not of type '\"", type, "\"'", call. = FALSE)
             }
-        }
+        } 
     }
 
     TRUE

--- a/tests/testthat/test-family-utils.R
+++ b/tests/testthat/test-family-utils.R
@@ -18,6 +18,7 @@ m_gaulss <- gam(list(y ~ s(x0) + s(x1) + s(x2) + s(x3), ~ 1), data = dat,
 m_gamm <- gamm(y ~ s(x0) + s(x1) + s(x2) + s(x3), data = dat)
 m_bam <- bam(y ~ s(x0) + s(x1) + s(x2) + s(x3), data = dat, method = "fREML")
 m_gamm4 <- gamm4(y ~ s(x0) + s(x1) + s(x2) + s(x3), data = dat)
+m_gam_scat <- gam(y ~ 1, data = dat, family = scat)
 
 l <- list(mer = 1:3, gam = 1:3)
 
@@ -91,6 +92,12 @@ test_that("inv_link() works with a bam() model", {
     f <- inv_link(m_bam)
     expect_type(f, "closure")
     expect_identical(f, gaussian()$linkinv)
+})
+
+test_that("inv_link() works with scaled t distribution", {
+  f <- inv_link(m_gam_scat)
+  expect_type(f, "closure")
+  expect_identical(f, scat()$linkinv)
 })
 
 test_that("inv_link.list() fails with a list that isn't a gamm4", {

--- a/tests/testthat/test-family-utils.R
+++ b/tests/testthat/test-family-utils.R
@@ -200,7 +200,7 @@ test_that("link() works for tw() family objects", {
 })
 
 test_that("link() works for scat() family objects", {
-    f <- link(scat())
+    f <- link(m_gam_scat)
     expect_type(f, "closure")
     expect_identical(f(val), scat()$linkfun(val))
     expect_identical(f, scat()$linkfun)


### PR DESCRIPTION
Simple fix to capture either `scaled t`, the family found in `scat()$family`, or `Scaled t(..., ...)` the family found in `gam(y~1, family = scat)$family`.  Closes #130 