### PR TITLE
draw.gam documentation for rug= argument for >1-D smooths

### DIFF
--- a/R/draw-gam.R
+++ b/R/draw-gam.R
@@ -53,7 +53,8 @@
 #'   The data are scaled into the unit square before deciding what to exclude,
 #'   and `dist` is a distance within the unit square. See
 #'   [mgcv::exclude.too.far()] for further details.
-#' @param rug logical; draw a rug plot at the botom of each plot?
+#' @param rug logical; draw a rug plot at the botom of each plot for 1-D
+#'   smooths or plot locations of data for higher dimensions.
 #' @param contour logical; should contours be draw on the plot using
 #'   [ggplot2::geom_contour()].
 #' @param ci_alpha numeric; alpha transparency for confidence or simultaneous

--- a/man/draw.gam.Rd
+++ b/man/draw.gam.Rd
@@ -108,7 +108,8 @@ The data are scaled into the unit square before deciding what to exclude,
 and \code{dist} is a distance within the unit square. See
 \code{\link[mgcv:exclude.too.far]{mgcv::exclude.too.far()}} for further details.}
 
-\item{rug}{logical; draw a rug plot at the botom of each plot?}
+\item{rug}{logical; draw a rug plot at the botom of each plot for 1-D
+smooths or plot locations of data for higher dimensions.}
 
 \item{contour}{logical; should contours be draw on the plot using
 \code{\link[ggplot2:geom_contour]{ggplot2::geom_contour()}}.}

--- a/man/draw.parametric_effects.Rd
+++ b/man/draw.parametric_effects.Rd
@@ -50,7 +50,8 @@ and confidence interval before plotting. Can be a function or the name of a
 function. Function \code{fun} will be applied after adding any \code{constant}, if
 provided.}
 
-\item{rug}{logical; draw a rug plot at the botom of each plot?}
+\item{rug}{logical; draw a rug plot at the botom of each plot for 1-D
+smooths or plot locations of data for higher dimensions.}
 
 \item{position}{Position adjustment, either as a string, or the result of a
 call to a position adjustment function.}

--- a/man/draw.smooth_samples.Rd
+++ b/man/draw.smooth_samples.Rd
@@ -78,7 +78,8 @@ If \code{scales = "free"} each univariate smooth has its own y-axis scale.
 Currently does not affect the y-axis scale of plots of the parametric
 terms.}
 
-\item{rug}{logical; draw a rug plot at the botom of each plot?}
+\item{rug}{logical; draw a rug plot at the botom of each plot for 1-D
+smooths or plot locations of data for higher dimensions.}
 
 \item{partial_match}{logical; should smooths be selected by partial matches
 with \code{select}? If \code{TRUE}, \code{select} can only be a single string to match

--- a/man/draw_parametric_effect.Rd
+++ b/man/draw_parametric_effect.Rd
@@ -58,7 +58,8 @@ supplied, a suitable label will be generated from \code{object}.}
 \item{caption}{character or expression; the plot caption. See
 \code{\link[ggplot2:labs]{ggplot2::labs()}}.}
 
-\item{rug}{logical; draw a rug plot at the botom of each plot?}
+\item{rug}{logical; draw a rug plot at the botom of each plot for 1-D
+smooths or plot locations of data for higher dimensions.}
 
 \item{position}{Position adjustment, either as a string, or the result of a
 call to a position adjustment function.}


### PR DESCRIPTION
just adding a bit of explanation for the `rug` argument, as it currently only refers to the 1-D case.