### PR TITLE
Suppress multiple match warning

### DIFF
--- a/R/draw-gam.R
+++ b/R/draw-gam.R
@@ -267,7 +267,9 @@
                     pluck("rng")
 
                 # merge with the evaluated smooth
-                sm_eval <- left_join(sm_eval, p_resids, by = "smooth")
+                sm_eval <- suppress_matches_multiple_warning(
+                  left_join(sm_eval, p_resids, by = "smooth")
+                )
             }
         }
 
@@ -277,7 +279,9 @@
             rug_data <- nested_rug_values(object, terms = S[select])
 
             # merge with the evaluated smooth
-            sm_eval <- left_join(sm_eval, rug_data, by = "smooth")
+            sm_eval <- suppress_matches_multiple_warning(
+              left_join(sm_eval, rug_data, by = "smooth")
+            )
         }
 
         # need to figure out scales if "fixed"
@@ -387,4 +391,17 @@
 #' @export
 `draw.gamm` <- function(object, ...) {
     draw(object$gam, ...)
+}
+
+# TODO: Remove after dplyr 1.1.0 is released and use `multiple = "all"` instead
+suppress_matches_multiple_warning <- function(expr) {
+  handler_matches_multiple <- function(cnd) {
+    if (inherits(cnd, "dplyr_warning_join_matches_multiple")) {
+      restart <- findRestart("muffleWarning")
+      if (!is.null(restart)) {
+        invokeRestart(restart)
+      }
+    }
+  }
+  withCallingHandlers(expr, warning = handler_matches_multiple)
 }


### PR DESCRIPTION
This PR makes your package compatible with the next version of dplyr:

The join functions in dplyr (like `left_join()`) now return a warning by default when a row in `x` matches _multiple_ rows in `y`. While this is typical SQL behavior, it is often unexpected during data analysis (many people don't even know it is possible), so we've decided to make this a warning. In dplyr 1.1.0, you silence this warning with `multiple = "all"`. In the meantime, to be compatible with both dev and CRAN dplyr we need to work around broken tests of yours that were expecting no output.

I _think_ I've fixed this by suppressing the warning anywhere you called a join function. I'll admit I was having trouble running your tests (I am on a Mac), but the changes I made seem to align with the failures I saw in the cloud revdepcheck results:

```r
══ Failed tests ════════════════════════════════════════════════════════════════
── Failure ('test-draw-gam.R:69'): draw.gam works for dlnm_m ───────────────────
`plt <- draw(dlnm_m, rug = FALSE)` produced warnings.
── Failure ('test-draw-smooth-estimates.R:56'): draw.smooth_estimates works for su_m_bivar ──
`plt <- draw(smooth_estimates(su_m_bivar, dist = 0.1))` produced warnings.
── Failure ('test-draw-smooth-estimates.R:62'): draw.smooth_estimates works for su_m_bivar_te ──
`plt <- draw(smooth_estimates(su_m_bivar_te, dist = 0.1))` produced warnings.
── Failure ('test-draw-smooth-estimates.R:67'): draw.smooth_estimates works for su_m_bivar_t2 ──
`plt <- draw(smooth_estimates(su_m_bivar_t2, dist = 0.1))` produced warnings.
── Failure ('test-smooth-estimates.R:103'): smooth_estimates works with a bivariate TPRS smooth with dist ──
`sm <- smooth_estimates(su_m_bivar, "s(x,z)", n = 50, dist = 0.1)` produced warnings.
── Failure ('test-smooth-estimates.R:122'): smooth_estimates works with a bivariate te smooth with dist ──
`sm <- smooth_estimates(su_m_bivar_te, "te(x,z)", n = 50, dist = 0.1)` produced warnings.

[ FAIL 6 | WARN 50 | SKIP 156 | PASS 1686 ]
```

If you could check against dev dplyr yourself to confirm, that would be great!

We plan to submit dplyr 1.1.0 on January 27th.

This should be compatible with both dev and CRAN dplyr. It would help us out if you could go ahead and send a patch version of your package to CRAN ahead of time! Thanks!